### PR TITLE
scripts/Run uses bash features, set the shebang appropriately

### DIFF
--- a/scripts/Run
+++ b/scripts/Run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Script to process multiple items on one rendering server
 
 LicensesDirectory=XML-Licenses


### PR DESCRIPTION
With the shebang set to `#!/bin/sh`, this script fails to run on any box where `/bin/sh` is not a symlink to `/bin/bash` (e.g., any Ubuntu or modern Debian system which uses Dash to provide `/bin/sh`).
