### PR TITLE
Group name must start with a non-digit in PCRE 8.34+

### DIFF
--- a/host-tools/offline-renderer/mediawiki-offline/includes/MagicWord.php
+++ b/host-tools/offline-renderer/mediawiki-offline/includes/MagicWord.php
@@ -542,7 +542,9 @@ class MagicWordArray {
 				$magic = MagicWord::get( $name );
 				$case = intval( $magic->isCaseSensitive() );
 				foreach ( $magic->getSynonyms() as $i => $syn ) {
-					$group = "(?P<{$i}_{$name}>" . preg_quote( $syn, '/' ) . ')';
+					// Group name must start with a non-digit in PCRE 8.34+
+					$it = strtr( $i, '0123456789', 'abcdefghij' );
+					$group = "(?P<{$it}_{$name}>" . preg_quote( $syn, '/' ) . ')';
 					if ( $this->baseRegex[$case] === '' ) {
 						$this->baseRegex[$case] = $group;
 					} else {

--- a/samo-lib/grifo/Mk/application-post.mk
+++ b/samo-lib/grifo/Mk/application-post.mk
@@ -96,7 +96,6 @@ simulate-makefile: simulate-files
 simulate-makefile: simulate simulate-files qmake-project
 	cd "${SIMULATE_DIR}" && \
 	qmake CONFIG+="qt warn_on thread debug" \
-	  QMAKE_CXXFLAGS_WARN_ON+='-Werror' QMAKE_CFLAGS_WARN_ON+='-Werror' \
 	  QMAKE_CXXFLAGS+='-DGRIFO_SIMULATOR=1' QMAKE_CFLAGS+='-DGRIFO_SIMULATOR=1' \
 	  QMAKE_LIBS+='-lrt'
 


### PR DESCRIPTION
Merged patch from:
https://gerrit.wikimedia.org/r/#/c/107259/1/includes/MagicWord.php

it appears to fix an error I get when building images with modern php libs
